### PR TITLE
Fix class name conflict with vendored migration.

### DIFF
--- a/database/migrations/2013_04_09_062329_create_revision_table.php
+++ b/database/migrations/2013_04_09_062329_create_revision_table.php
@@ -2,7 +2,7 @@
 
 use Illuminate\Database\Migrations\Migration;
 
-class CreateRevisionsTable extends Migration
+class CreateRevisionTable extends Migration
 {
     /**
      * Run the migrations.


### PR DESCRIPTION
#### Changes
This fixes an error message when Composer encountered the two un-namespaced migration classes with the same class name. Renaming our copied one to `CreateRevisionTable` fixes the issue.

```
Warning: Ambiguous class resolution, "CreateRevisionsTable" was found in both "$baseDir . '/database/migrations/2013_04_09_062329_create_revisions_table.php" and "/home/vagrant/Sites/content-prototype/vendor/venturecraft/revisionable/src/migrations/2013_04_09_062329_create_revisions_table.php", the first will be used.
```

---
For review: @weerd 